### PR TITLE
Fix hanging `npm create astro` command

### DIFF
--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -278,6 +278,7 @@ async function createProjectStructure(projectPath, name, options, pbCreds) {
       "npm",
       [
         "create",
+        "--yes",
         "astro@latest",
         ".",
         "--",


### PR DESCRIPTION
The`npm create astro` step currently hangs unless you already have the package installed.

That's because npm requires confirmation in the shell when installing a new package, this can be overridden with the `--yes` param.